### PR TITLE
Fix error when refreshing on favorites page

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -49,16 +49,26 @@ export function unfavoriteGif({selectedGif}) {
 }
 
 export function fetchFavoritedGifs() {
-  return function(dispatch) {
-    const userUid = Firebase.auth().currentUser.uid;
-
-    Firebase.database().ref(userUid).on('value', snapshot => {
+  const fetchFavorites = (uid, dispatch) => {
+    Firebase.database().ref(uid).on('value', snapshot => {
       dispatch({
         type: FETCH_FAVORITED_GIFS,
         payload: snapshot.val()
-      })
+      });
     });
-  }
+  };
+
+  return function(dispatch) {
+    const userUid = Firebase.auth().currentUser && Firebase.auth().currentUser.uid;
+
+    if (userUid != null) {
+      fetchFavorites(userUid, dispatch);
+    } else {
+      Firebase.auth().onAuthStateChanged(user => {
+        fetchFavorites(user.uid, dispatch);
+      });
+    }
+  };
 }
 
 export function openModal(gif) {


### PR DESCRIPTION
This fixes an initialization error caused by fetching the a user's uid before Firebase has responded, such as after a page refresh.